### PR TITLE
Add mysql support and API route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=your_password
+DB_NAME=stock_lab

--- a/app/api/platforms/route.ts
+++ b/app/api/platforms/route.ts
@@ -1,0 +1,9 @@
+import { getDb } from '@/lib/db';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type');
+  const db = await getDb();
+  const [rows] = await db.query('SELECT * FROM platform_services WHERE ? IS NULL OR service_type = ? ORDER BY sort_order', [type, type]);
+  return Response.json(rows);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -39,134 +39,51 @@ export default function EnterpriseStockToolbox() {
   const [newItemType, setNewItemType] = useState("platform");
 
   // 管理平台配置
-  const [managementPlatforms, setManagementPlatforms] = useState<
-    PlatformItem[]
-  >([
-    {
-      id: "ainews",
-      name: "AINEWS运营管理",
-      description: "AI新闻内容管理和发布平台",
-      icon: getIconByName("FileText"),
-      iconName: "FileText",
-      status: "运行中",
-      url: "/ainews-admin",
-      color: "bg-blue-500",
-    },
-    {
-      id: "indicators",
-      name: "指标服务管理",
-      description: "金融指标数据服务运营管理",
-      icon: getIconByName("BarChart3"),
-      iconName: "BarChart3",
-      status: "运行中",
-      url: "/indicators-admin",
-      color: "bg-green-500",
-    },
-    {
-      id: "f9menu",
-      name: "F9菜单管理",
-      description: "F9快捷菜单配置和权限管理",
-      icon: getIconByName("Settings"),
-      iconName: "Settings",
-      status: "运行中",
-      url: "/f9menu-admin",
-      color: "bg-purple-500",
-    },
-    {
-      id: "research",
-      name: "券商研报权限",
-      description: "定制券商研报访问权限管理",
-      icon: getIconByName("Shield"),
-      iconName: "Shield",
-      status: "运行中",
-      url: "/research-admin",
-      color: "bg-orange-500",
-    },
-    {
-      id: "docparser",
-      name: "DocParser密钥管理",
-      description: "文档解析服务API密钥管理",
-      icon: getIconByName("Key"),
-      iconName: "Key",
-      status: "运行中",
-      url: "/docparser-admin",
-      color: "bg-red-500",
-    },
-    {
-      id: "enti",
-      name: "ENTI管理员设置",
-      description: "企业实体管理员权限配置",
-      icon: getIconByName("Users"),
-      iconName: "Users",
-      status: "运行中",
-      url: "/enti-admin",
-      color: "bg-indigo-500",
-    },
-    {
-      id: "email",
-      name: "邮件订阅管理",
-      description: "邮件订阅服务运营管理",
-      icon: getIconByName("Mail"),
-      iconName: "Mail",
-      status: "运行中",
-      url: "/email-admin",
-      color: "bg-pink-500",
-    },
-    {
-      id: "prompt",
-      name: "Prompt管理平台",
-      description: "AI提示词模板管理和优化",
-      icon: getIconByName("Code"),
-      iconName: "Code",
-      status: "运行中",
-      url: "/prompt-admin",
-      color: "bg-teal-500",
-    },
-  ]);
+  const [managementPlatforms, setManagementPlatforms] = useState<PlatformItem[]>([]);
 
   // 技术服务工具
-  const [techServices, setTechServices] = useState<ServiceItem[]>([
-    {
-      id: "ocean",
-      name: "Ocean服务",
-      description: "海量数据处理服务",
-      icon: getIconByName("Database"),
-      iconName: "Database",
-      url: "/ocean",
-    },
-    {
-      id: "cloud",
-      name: "Cloud服务",
-      description: "云计算资源管理",
-      icon: getIconByName("Cloud"),
-      iconName: "Cloud",
-      url: "/cloud",
-    },
-    {
-      id: "wss",
-      name: "WSS指标服务",
-      description: "WebSocket实时指标推送",
-      icon: getIconByName("Zap"),
-      iconName: "Zap",
-      url: "/wss",
-    },
-    {
-      id: "rag",
-      name: "RAG服务",
-      description: "检索增强生成服务",
-      icon: getIconByName("Globe"),
-      iconName: "Globe",
-      url: "/rag",
-    },
-    {
-      id: "html2img",
-      name: "HTML转图工具",
-      description: "HTML页面转图片工具",
-      icon: getIconByName("FileText"),
-      iconName: "FileText",
-      url: "/html2img",
-    },
-  ]);
+  const [techServices, setTechServices] = useState<ServiceItem[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const resPlatform = await fetch('/api/platforms?type=platform');
+        if (resPlatform.ok) {
+          const data = await resPlatform.json();
+          setManagementPlatforms(
+            data.map((item: any) => ({
+              id: item.service_code,
+              name: item.service_name,
+              description: item.service_description,
+              icon: getIconByName(item.icon_name),
+              iconName: item.icon_name,
+              status: item.is_visible ? '运行中' : '停用',
+              url: item.service_url,
+              color: item.color_class,
+            }))
+          );
+        }
+        const resService = await fetch('/api/platforms?type=service');
+        if (resService.ok) {
+          const data = await resService.json();
+          setTechServices(
+            data.map((item: any) => ({
+              id: item.service_code,
+              name: item.service_name,
+              description: item.service_description,
+              icon: getIconByName(item.icon_name),
+              iconName: item.icon_name,
+              url: item.service_url,
+              color: item.color_class,
+            }))
+          );
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
 
   const handleAddNew = (type: string) => {
     setNewItemType(type);

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,0 +1,75 @@
+-- SQL initialization script for stock_lab database
+-- Create database if not exists executed separately
+
+-- Users table
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `username` varchar(50) NOT NULL COMMENT '用户名',
+  `password` varchar(255) NOT NULL COMMENT '用户密码（加密存储）',
+  `nickname` varchar(100) DEFAULT NULL COMMENT '用户昵称',
+  `email` varchar(100) DEFAULT NULL COMMENT '邮箱地址',
+  `is_active` tinyint(1) NOT NULL DEFAULT 1 COMMENT '是否激活，1=激活，0=禁用',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_username` (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户表';
+
+INSERT INTO `users` (`username`, `password`, `nickname`, `email`)
+VALUES ('admin', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', '系统管理员', 'admin@company.com')
+ON DUPLICATE KEY UPDATE username=username;
+
+-- Platform services table
+CREATE TABLE IF NOT EXISTS `platform_services` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `service_code` varchar(50) NOT NULL COMMENT '服务代码，唯一标识',
+  `service_name` varchar(100) NOT NULL COMMENT '服务名称',
+  `service_description` text COMMENT '服务描述信息',
+  `service_type` enum('platform','service') NOT NULL DEFAULT 'platform' COMMENT '服务类型：platform=管理平台，service=技术服务',
+  `icon_name` varchar(50) NOT NULL DEFAULT 'Settings' COMMENT '图标名称，对应lucide-react图标',
+  `color_class` varchar(50) NOT NULL DEFAULT 'bg-blue-500' COMMENT '颜色CSS类名',
+  `service_url` varchar(500) NOT NULL COMMENT '服务访问地址',
+  `sort_order` int(11) NOT NULL DEFAULT 0 COMMENT '排序权重，数字越小越靠前',
+  `is_visible` tinyint(1) NOT NULL DEFAULT 1 COMMENT '是否可见，1=可见，0=隐藏',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_service_code` (`service_code`),
+  KEY `idx_service_type` (`service_type`),
+  KEY `idx_sort_order` (`sort_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='平台服务配置表';
+
+-- Technical services and management platforms initial data
+INSERT INTO `platform_services` (`service_code`, `service_name`, `service_description`, `service_type`, `icon_name`, `color_class`, `service_url`, `sort_order`)
+VALUES
+('ainews', 'AINEWS运营管理', 'AI新闻内容管理和发布平台', 'platform', 'FileText', 'bg-blue-500', '/ainews-admin', 1),
+('indicators', '指标服务管理', '金融指标数据服务运营管理', 'platform', 'BarChart3', 'bg-green-500', '/indicators-admin', 2),
+('f9menu', 'F9菜单管理', 'F9快捷菜单配置和权限管理', 'platform', 'Settings', 'bg-purple-500', '/f9menu-admin', 3),
+('research', '券商研报权限', '定制券商研报访问权限管理', 'platform', 'Shield', 'bg-orange-500', '/research-admin', 4),
+('docparser', 'DocParser密钥管理', '文档解析服务API密钥管理', 'platform', 'Key', 'bg-red-500', '/docparser-admin', 5),
+('enti', 'ENTI管理员设置', '企业实体管理员权限配置', 'platform', 'Users', 'bg-indigo-500', '/enti-admin', 6),
+('email', '邮件订阅管理', '邮件订阅服务运营管理', 'platform', 'Mail', 'bg-pink-500', '/email-admin', 7),
+('prompt', 'Prompt管理平台', 'AI提示词模板管理和优化', 'platform', 'Code', 'bg-teal-500', '/prompt-admin', 8),
+('ocean', 'Ocean服务', '海量数据处理服务', 'service', 'Database', 'bg-blue-500', '/ocean', 1),
+('cloud', 'Cloud服务', '云计算资源管理', 'service', 'Cloud', 'bg-green-500', '/cloud', 2),
+('wss', 'WSS指标服务', 'WebSocket实时指标推送', 'service', 'Zap', 'bg-purple-500', '/wss', 3),
+('rag', 'RAG服务', '检索增强生成服务', 'service', 'Globe', 'bg-orange-500', '/rag', 4),
+('html2img', 'HTML转图工具', 'HTML页面转图片工具', 'service', 'FileText', 'bg-red-500', '/html2img', 5)
+ON DUPLICATE KEY UPDATE service_code=service_code;
+
+-- User operation logs table
+CREATE TABLE IF NOT EXISTS `user_operation_logs` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `user_id` bigint(20) unsigned NOT NULL COMMENT '用户ID',
+  `operation_type` varchar(50) NOT NULL COMMENT '操作类型：add=新增，update=修改，delete=删除，access=访问',
+  `service_code` varchar(50) DEFAULT NULL COMMENT '操作的服务代码',
+  `operation_detail` text COMMENT '操作详情，JSON格式记录具体变更内容',
+  `ip_address` varchar(45) DEFAULT NULL COMMENT '操作IP地址',
+  `user_agent` varchar(500) DEFAULT NULL COMMENT '用户代理信息',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '操作时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_operation_type` (`operation_type`),
+  KEY `idx_service_code` (`service_code`),
+  KEY `idx_created_at` (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户操作日志表';

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,60 @@
+import mysql from 'mysql2/promise';
+import fs from 'fs/promises';
+import path from 'path';
+import { config } from 'dotenv';
+
+// Load environment variables from .env if present
+config();
+
+export interface DbConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+const dbConfig: DbConfig = {
+  host: process.env.DB_HOST || 'localhost',
+  port: Number(process.env.DB_PORT) || 3306,
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_NAME || 'stock_lab',
+};
+
+// Create connection pool without specifying database for initialization
+const pool = mysql.createPool({
+  host: dbConfig.host,
+  port: dbConfig.port,
+  user: dbConfig.user,
+  password: dbConfig.password,
+  waitForConnections: true,
+  connectionLimit: 10,
+  multipleStatements: true,
+});
+
+export async function initializeDatabase() {
+  const connection = await pool.getConnection();
+  try {
+    await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbConfig.database}\``);
+    await connection.query(`USE \`${dbConfig.database}\``);
+    const initSqlPath = path.join(process.cwd(), 'database', 'init.sql');
+    const sql = await fs.readFile(initSqlPath, 'utf8');
+    // mysql2 by default does not support multiple statements without this option
+    await connection.query(sql);
+  } finally {
+    connection.release();
+  }
+}
+
+export async function getDb() {
+  // Ensure DB and tables exist
+  await initializeDatabase();
+  // Return a pool configured with the database name
+  return mysql.createPool({
+    ...dbConfig,
+    waitForConnections: true,
+    connectionLimit: 10,
+    multipleStatements: true,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",
+    "mysql2": "^3.9.7",
+    "dotenv": "^16.3.1",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- add `.env.example` for database settings
- create `lib/db.ts` to manage mysql connections and initialization
- add database schema initialization script
- expose `/api/platforms` route to read from DB
- fetch data from API on the main page
- add mysql2 and dotenv dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run lint` *(fails: next not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68831a0c78a08323a6b2d594c8c9f38f